### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -2,6 +2,8 @@
 # been successful or failed. Appropriate messages are then sent afterwards on each event type
 # Ref https://github.com/rtCamp/action-slack-notify
 name: Slack Notification
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/BrianLusina/rustic-cargo/security/code-scanning/7](https://github.com/BrianLusina/rustic-cargo/security/code-scanning/7)

To fix this problem, we should add a `permissions` block to the workflow. This can be added at the root level (to apply to all jobs in the workflow), or at each job level for finer control. Since neither `onSuccess` nor `onFailure` appears to require write access (they only send Slack notifications), we can safely set the minimum necessary permissions, which is typically `contents: read`. This reduces the GITHUB_TOKEN's scope in these jobs and follows GitHub's security best practice.

The best fix is to add a root-level `permissions` block immediately after the `name` and before `on:`. No other code changes or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
